### PR TITLE
Add simple browser extension using Endless SDK

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,20 @@
+# Browser Extension
+
+This folder contains a simple Chrome extension that demonstrates how to use the Endless TypeScript SDK.
+
+## Build
+
+Run the following command from the repository root to compile the TypeScript sources:
+
+```bash
+pnpm run build:extension
+```
+
+The compiled files will be placed in `extension/dist`.
+
+## Load the extension
+
+1. Open `chrome://extensions` in your browser.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this `extension` directory.
+4. The popup allows you to create an account and submit transactions on the local network.

--- a/extension/background.ts
+++ b/extension/background.ts
@@ -1,0 +1,34 @@
+import { Account, Endless, EndlessConfig, Network } from "@endlesslab/endless-ts-sdk";
+
+const endless = new Endless(new EndlessConfig({ network: Network.LOCAL }));
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  (async () => {
+    if (message.type === "createAccount") {
+      const account = Account.generate();
+      sendResponse({ address: account.accountAddress.toString(), privateKey: account.privateKey.toString() });
+      return;
+    }
+
+    if (message.type === "transfer") {
+      const { privateKey, to, amount } = message;
+      try {
+        const account = await Account.fromPrivateKey({ privateKey });
+        const transaction = await endless.transaction.build.simple({
+          sender: account.accountAddress,
+          data: {
+            function: "0x1::coin::transfer",
+            typeArguments: ["0x1::endless_coin::EndlessCoin"],
+            functionArguments: [to, amount],
+          },
+        });
+        const committed = await endless.signAndSubmitTransaction({ signer: account, transaction });
+        sendResponse({ success: true, hash: committed.hash });
+      } catch (e) {
+        sendResponse({ success: false, error: (e as Error).message });
+      }
+      return;
+    }
+  })();
+  return true;
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,9 @@
+{
+  "manifest_version": 3,
+  "name": "Endless Wallet",
+  "version": "0.1",
+  "action": { "default_popup": "popup.html" },
+  "background": { "service_worker": "dist/background.js" },
+  "permissions": ["storage", "scripting"],
+  "host_permissions": ["http://127.0.0.1:8080/*"]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Endless Wallet</title>
+</head>
+<body>
+  <button id="create">Create Account</button>
+  <div>Address: <span id="address"></span></div>
+  <div>
+    <input id="recipient" placeholder="Recipient" />
+    <input id="amount" placeholder="Amount" type="number" />
+    <button id="send">Send</button>
+  </div>
+  <script src="dist/popup.js"></script>
+</body>
+</html>

--- a/extension/popup.ts
+++ b/extension/popup.ts
@@ -1,0 +1,32 @@
+const createBtn = document.getElementById("create") as HTMLButtonElement;
+const addressSpan = document.getElementById("address") as HTMLElement;
+const recipientInput = document.getElementById("recipient") as HTMLInputElement;
+const amountInput = document.getElementById("amount") as HTMLInputElement;
+const sendBtn = document.getElementById("send") as HTMLButtonElement;
+
+let privateKey: string | undefined;
+
+createBtn.addEventListener("click", () => {
+  chrome.runtime.sendMessage({ type: "createAccount" }, (response) => {
+    addressSpan.textContent = response.address;
+    privateKey = response.privateKey;
+  });
+});
+
+sendBtn.addEventListener("click", () => {
+  if (!privateKey) {
+    return;
+  }
+  chrome.runtime.sendMessage(
+    { type: "transfer", privateKey, to: recipientInput.value, amount: Number(amountInput.value) },
+    (res) => {
+      if (res.success) {
+        // eslint-disable-next-line no-alert
+        alert(`Tx hash: ${res.hash}`);
+      } else {
+        // eslint-disable-next-line no-alert
+        alert(res.error);
+      }
+    },
+  );
+});

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "esnext",
+    "target": "es2020"
+  },
+  "include": ["*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build:clean": "rm -rf dist",
     "build": "tsup",
     "build:watch": "tsup --watch",
+    "build:extension": "tsup extension/*.ts --out-dir extension/dist",
     "_fmt": "prettier 'src/**/*.ts' 'examples/**/*.ts' '.eslintrc.js'",
     "lint": "eslint 'src/**/*.ts' 'examples/**/*.ts'"
   },


### PR DESCRIPTION
## Summary
- add `extension` folder with Chrome extension boilerplate
- implement background logic that instantiates Endless SDK
- provide popup interface to create accounts and send transactions
- document build and install steps
- expose `build:extension` script in `package.json`

## Testing
- `npm run build:extension` *(fails: tsup not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684a955e4fd0832aa601f8e9b7c6a505